### PR TITLE
Update to latest ArcGIS API for JavaScript (4.12)

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,10 @@
     <meta http-equiv="Content-Security-Policy" content="upgrade-insecure-requests">
     <meta name="viewport" content="width=device-width, user-scalable=no">
     <link rel="stylesheet" href="//s3-us-west-1.amazonaws.com/patterns.esri.com/files/calcite-web/1.2.4/css/calcite-web.min.css">
-    <link rel="stylesheet" href="//js.arcgis.com/4.3/esri/css/main.css">
+    <link rel="stylesheet" href="//js.arcgis.com/4.12/esri/css/main.css">
     <link rel="stylesheet" href="./css/boilerplate.css">
     <script type="text/javascript" src="./js/dojoConfig.js"></script>
-    <script type="text/javascript" src="//js.arcgis.com/4.3/"></script>
+    <script type="text/javascript" src="//js.arcgis.com/4.12/"></script>
     <script type="text/javascript">
       require([
         "boilerplate",


### PR DESCRIPTION
Hi John,
I've been trying to use your ProjectTimeline app to show a 3D BuildingSceneLayer, but noticed that I have to update the API version first. I did some regression testing but can't tell if all original functionality is preserved. Anyhow, here is a PR just for upgrading to the latest API.

The changes involve:

* Increased API version from 4.3 to 4.12
* Replaced layer view controller with `queryFeatures()` from layer, could probably use client side `queryFeatures()`
* Import `"dojo/NodeList-dom"` to support new Dojo version

Cheers,
Arno